### PR TITLE
Fixed FixupFirstLefts1 calling ParseFirstLeft

### DIFF
--- a/clipper.js
+++ b/clipper.js
@@ -5599,7 +5599,7 @@
 			var outRec = this.m_PolyOuts[i];
 			if (outRec.Pts == null || outRec.FirstLeft == null)
 				continue;
-			var firstLeft = this.ParseFirstLeft(outRec.FirstLeft);
+			var firstLeft = ClipperLib.Clipper.ParseFirstLeft(outRec.FirstLeft);
 			if (firstLeft == OldOutRec)
 			{
         if (this.Poly2ContainsPoly1(outRec.Pts, NewOutRec.Pts))


### PR DESCRIPTION
FIxed an error occuring during some weird cases (I don't have a reproductible example unfortunately).

```
TypeError: this.ParseFirstLeft is not a function
    at ClipperLib.Clipper.FixupFirstLefts1 (clipper.js:5602)
    at ClipperLib.Clipper.JoinCommonEdges (clipper.js:5697)
    at ClipperLib.Clipper.ExecuteInternal (clipper.js:3217)
    at ClipperLib.Clipper.Execute (clipper.js:3152)
```