### PR TITLE
Fix closing `<table>` tag in Documentation.md

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -1261,7 +1261,7 @@ PolyTrees can also contain open paths. Open paths will always be represented by 
                 IsHole = <b>False</b>
                 ChildCount = <b>0</b>
 
-            </pre></td></tr></table>
+</pre></td></tr></table>
 
 **See also:**
 <a href="#overview">Overview</a>, <a href="#clipper">Clipper</a>, <a href="#clipperlibclipperexecute">Clipper.Execute</a>, <a href="#clipperlibpolynode">PolyNode</a>, <a href="#clipperlibclipperclosedpathsfrompolytree">ClosedPathsFromPolyTree</a>, <a href="#clipperlibclipperopenpathsfrompolytree">OpenPathsFromPolyTree</a>, <a href="#clipperlibpaths">Paths</a>


### PR DESCRIPTION
The alignment of these closing tags were preventing the docs from rendering correctly on [GitHub](https://github.com/junmer/clipper-lib/blob/master/Documentation.md#polytree) and in VS Code's Markdown Preview.

# Currently

![Screenshot 2023-06-02 at 1 57 00 PM](https://github.com/junmer/clipper-lib/assets/1214349/36dd7b76-d0c7-4e35-bd5c-bd70d453546e)

# With the HTML fix

![Screenshot 2023-06-02 at 1 57 35 PM](https://github.com/junmer/clipper-lib/assets/1214349/a9fca757-457f-434b-b6a1-ee417857008b)

Screen shots are from VS Code's Markdown Preview, but this can also be seen on GitHub (linked above).

Also, thank you for porting this library to JavaScript!